### PR TITLE
Update requirements.txt: Double requirement given: Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ future
 lmdb
 numpy
 opencv-python
-Pillow
 pyyaml
 requests
 scikit-image


### PR DESCRIPTION
When installing, one can get an error: "ERROR: Double requirement given: Pillow (from -r requirements.txt (line 8)) (already in pillow>=9.5.0 (from -r requirements.txt (line 1)), name='Pillow')"